### PR TITLE
Install mlocate for quicker SeafloorMapping file finds

### DIFF
--- a/smdb/compose/local/django/Dockerfile
+++ b/smdb/compose/local/django/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gettext \
   postgresql-client \
   python3-pip \
+  # For quicker SeafloorMapping file finds
+  mlocate \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*

--- a/smdb/compose/production/django/Dockerfile
+++ b/smdb/compose/production/django/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libpq-dev \
   # Translations dependencies
   gettext \
+  # For quicker SeafloorMapping file finds
+  mlocate \
   postgresql-client \
   python3-pip \
   # cleaning up unused files


### PR DESCRIPTION
Would like to be able to do this in cron on smdb:
```
updatedb -l 0 -o SeafloorMapping.db -U /mbari/SeafloorMapping -e /mbari/SeafloorMapping/.snapshots
```
and then run `locate ZTopo.grd` much more quicly.