### PR TITLE
Mount volume in django to hold mlocate database and ZTopo.grd file lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ you will clone this repository. Clone the repo and start the services with
 these commands:
 
 ```
+# cd to a development directory, e.g. ~/dev
+mkdir docker_smdb_vol 
 git clone git@github.com:mbari-org/SeafloorMappingDB.git
 cd SeafloorMappingDB
 export SMDB_HOME=$(pwd)
@@ -58,6 +60,7 @@ docker-compose up -d
 ```
 sudo -u docker_user -i
 cd /opt
+mkdir docker_smdb_vol && chown docker_user docker_smdb_vol
 git clone git@github.com:mbari-org/SeafloorMappingDB.git
 cd /opt/SeafloorMappingDB
 export SMDB_HOME=$(pwd)

--- a/smdb/local.yml
+++ b/smdb/local.yml
@@ -22,6 +22,9 @@ services:
     ports:
       - "8000:8000"
     command: /start
+    volumes:
+      # Edit to use directory on your host
+      - /Users/mccann/docker_smdb_vol:/etc/smdb:z
 
   postgres:
     build:

--- a/smdb/production.yml
+++ b/smdb/production.yml
@@ -18,6 +18,8 @@ services:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
     command: /start
+    volumes:
+      - /opt/docker_smdb_vol:/etc/smdb:z
 
   postgres:
     build:


### PR DESCRIPTION
Can now create the mlocate database thusly on development machine:
```
docker-compose run --rm -u 399 -v /Volumes/SeafloorMapping:/mbari/SeafloorMapping django updatedb -l 0 -o /etc/smdb/SeafloorMapping.db -U /mbari/SeafloorMapping -e /mbari/SeafloorMapping/.snapshot -v
```
Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/6.