### PR TITLE
Make 'ssh mb-system mbinfo' work in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ export SMDB_HOME=$(pwd)
 ```
 sudo -u docker_user -i
 cd /opt/SeafloorMappingDB
+export DOCKER_USER_ID=$(id -u)
 export SMDB_HOME=$(pwd)
 export COMPOSE_FILE=$SMDB_HOME/smdb/production.yml
 docker-compose up -d

--- a/smdb/compose/production/django/Dockerfile
+++ b/smdb/compose/production/django/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:10-stretch-slim as client-builder
 
+ARG DOCKER_USER_ID
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
 
@@ -11,9 +12,12 @@ RUN npm run build
 # Base the build off of recent stable GDAL image
 FROM osgeo/gdal:ubuntu-small-3.3.0 as python
 
+ARG DOCKER_USER_ID
+
 # Python build stage
 FROM python as python-build-stage
 
+ARG DOCKER_USER_ID
 ARG BUILD_ENVIRONMENT=production
 
 # Install apt packages
@@ -37,6 +41,7 @@ RUN pip wheel --wheel-dir /usr/src/app/wheels  \
 # Python 'run' stage
 FROM python as python-run-stage
 
+ARG DOCKER_USER_ID
 ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app
 
@@ -48,6 +53,8 @@ WORKDIR ${APP_HOME}
 
 RUN addgroup --system django \
     && adduser --system --ingroup django django
+
+RUN useradd docker_user -u $DOCKER_USER_ID -g 0
 
 
 # Install required system dependencies
@@ -62,6 +69,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   mlocate \
   postgresql-client \
   python3-pip \
+  ssh-client \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*

--- a/smdb/compose/production/mb-system/Dockerfile
+++ b/smdb/compose/production/mb-system/Dockerfile
@@ -1,0 +1,9 @@
+FROM  mbari/mbsystem:latest
+
+# Need to create home directory before .ssh volume is mounted by production.yml
+ARG DOCKER_USER_ID
+RUN useradd docker_user -u $DOCKER_USER_ID -g 0
+RUN echo "export LD_LIBRARY_PATH=/usr/local/lib64" >> /home/docker_user/.bashrc
+# https://stackoverflow.com/a/39044217
+RUN echo "LANG=en_US.UTF-8" >> /etc/environment
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment

--- a/smdb/production.yml
+++ b/smdb/production.yml
@@ -49,3 +49,13 @@ services:
 
   redis:
     image: redis:5.0
+
+  mb-system:
+    image: mbari/mbsystem:latest
+    container_name: mb-system
+    volumes:
+      # Edit source path to use directories from *your* host
+      # Copy your public key to your ~/.ssh/authorized_keys file
+      - /Users/mccann/.ssh:/root/.ssh:z
+      - /Volumes/SeafloorMapping:/mbari/SeafloorMapping:z
+    command: /usr/sbin/sshd -D

--- a/smdb/production.yml
+++ b/smdb/production.yml
@@ -11,6 +11,8 @@ services:
     build:
       context: .
       dockerfile: ./compose/production/django/Dockerfile
+      args:
+        - DOCKER_USER_ID=$DOCKER_USER_ID
     image: smdb_production_django
     depends_on:
       - postgres
@@ -20,6 +22,8 @@ services:
       - ./.envs/.production/.postgres
     command: /start
     volumes:
+      - /home/docker_user/.ssh:/home/docker_user/.ssh:z
+      - /mbari/SeafloorMapping:/mbari/SeafloorMapping:z
       - /opt/docker_smdb_vol:/etc/smdb:z
       - local_media_files:/media:z
 
@@ -51,11 +55,18 @@ services:
     image: redis:5.0
 
   mb-system:
-    image: mbari/mbsystem:latest
+    build:
+      # Build image that has user docker_user already added - needed before volume mount
+      # Make sure DOCKER_USER_ID is set in the environment before build - see README.md
+      context: .
+      dockerfile: ./compose/production/mb-system/Dockerfile
+      args:
+        - DOCKER_USER_ID=$DOCKER_USER_ID
+    image: mb-system
     container_name: mb-system
     volumes:
       # Edit source path to use directories from *your* host
       # Copy your public key to your ~/.ssh/authorized_keys file
-      - /Users/mccann/.ssh:/root/.ssh:z
-      - /Volumes/SeafloorMapping:/mbari/SeafloorMapping:z
+      - /home/docker_user/.ssh:/home/docker_user/.ssh:z
+      - /mbari/SeafloorMapping:/mbari/SeafloorMapping:z
     command: /usr/sbin/sshd -D

--- a/smdb/requirements/base.txt
+++ b/smdb/requirements/base.txt
@@ -11,7 +11,7 @@ psycopg2==2.9.1  # https://github.com/psycopg/psycopg2
 # Django
 # ------------------------------------------------------------------------------
 django==3.2.7  # pyup: < 3.2  # https://www.djangoproject.com/
-django-bleach==0.7.2  # https://pypi.org/project/django-bleach/
+django-bleach==0.8.0  # https://pypi.org/project/django-bleach/
 django-environ==0.7.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.1.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.45.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
The production containers need to run as unprivileged users, not root. Need to update the Docker builds to allow ssh as the container's user. Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/50.