### PR TITLE
Add Misison detail link to popup on overview page

### DIFF
--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -13,7 +13,11 @@ let feature = L.geoJSON(missions)
   .bindPopup(
     function (layer) {
       return (
+        "<a target='_blank' href='/missions/" +
+        layer.feature.properties.pk +
+        "'>" +
         layer.feature.properties.name +
+        "</a>" +
         "<br>" +
         "<img src='" +
         media_url +


### PR DESCRIPTION
Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/59