### PR TITLE
 Following zoom event add viewport's geospatial bounds to query

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,12 +34,11 @@
       "request": "launch",
       "program": "${workspaceFolder}/smdb/scripts/load.py",
       "console": "integratedTerminal",
-      //"args": ["-v", "2", "--regex", "mbsystem/Data/2019/20191106m3/ZTopo.grd$"],
-      //"args": ["-v", "2", "--regex", "MappingAUVOps2015/20150312m2/ZTopo.grd$"],
-      //"args": ["-v", "1", "--regex", "MappingAUVOps2013/TN293_Moyer13/sentry171/sentry171-raw/ZTopo.grd$", "--limit", "1"],
+      //"args": ["-v", "1", "--skipuntil_regex", "--regex", "2020/20200220d1/lidar/ZTopo.grd$", "--limit", "2"],
       //"args": ["-v", "1", "--bootstrap", "--skipuntil_regex", "--regex", "OceanImaging2013/monterey/ZTopo.grd$"],
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "MappingAUVOps2016/20160321m1/ZTopo.grd$", "--limit", "1"],
-      "args": ["-v", "--limit", "20", "--clobber", "--noinput"],
+      //"args": ["-v", "1", "--skipuntil_regex", "--regex", "2020/20200924t1/lidar/ZTopo.grd$", "--limit", "1"],
+      //"args": ["-v", "--limit", "20", "--clobber", "--noinput"],
       //"args": ["--bootstrap", "-v 2", "--clobber", "--limit", "50"],
       //"args": ["--bootstrap", "-v 2", "--limit", "10" "--clobber", "--noinput"],
       //"args": ["--notes", "-v 2", "--limit", "1"],
@@ -47,7 +46,8 @@
       //"args": ["--mbinfo", "-v", "2", "--skipuntil", "2021/20210326m1"],
       //"args": ["--mbinfo", "-v", "1", "--limit", "1", "--skipuntil", "2019/20190628d1/lidar"],
       //"args": ["--bootstrap", "-v", "2", "--limit", "2", "--skipuntil_regex", "--regex", "2020/20200804m1/ZTopo.grd" ],
-      //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2020/20200804m1"],
+      //"args": ["--fnv", "-v", "1", "--limit", "2", "--skipuntil", "2020/20200220d1/lidartest"],
+      "args": ["--fnv", "-v", "1"],
       "justMyCode": false
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/smdb/scripts/load.py",
       "console": "integratedTerminal",
-      //"args": ["-v", "1", "--skipuntil_regex", "--regex", "2020/20200220d1/lidar/ZTopo.grd$", "--limit", "2"],
+      //"args": ["-v", "1", "--skipuntil_regex", "--regex", "MappingAUVOps2011/20110718m1/ZTopo.grd$", "--limit", "2"],
       //"args": ["-v", "1", "--bootstrap", "--skipuntil_regex", "--regex", "OceanImaging2013/monterey/ZTopo.grd$"],
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "MappingAUVOps2016/20160321m1/ZTopo.grd$", "--limit", "1"],
       //"args": ["-v", "1", "--skipuntil_regex", "--regex", "2020/20200924t1/lidar/ZTopo.grd$", "--limit", "1"],
@@ -46,7 +46,7 @@
       //"args": ["--mbinfo", "-v", "2", "--skipuntil", "2021/20210326m1"],
       //"args": ["--mbinfo", "-v", "1", "--limit", "1", "--skipuntil", "2019/20190628d1/lidar"],
       //"args": ["--bootstrap", "-v", "2", "--limit", "2", "--skipuntil_regex", "--regex", "2020/20200804m1/ZTopo.grd" ],
-      //"args": ["--fnv", "-v", "1", "--limit", "2", "--skipuntil", "2020/20200220d1/lidartest"],
+      //"args": ["--fnv", "-v", "1", "--limit", "2", "--skipuntil", "MappingAUVOps2011/20110718m1"],
       "args": ["--fnv", "-v", "1"],
       "justMyCode": false
     }

--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -401,9 +401,18 @@ class FNVLoader(BaseLoader):
                 except IndexError:
                     self.logger.debug("Cannot read last record from %s", fnv_file)
                     continue
+                try:
+                    end_dt = parse("{}-{}-{} {}:{}:{}".format(*line.split()[:6]))
+                except IndexError:
+                    self.logger.debug("Failed to parse datetime from %s", line)
+                    continue
+                try:
+                    lon = float(line.split()[7])
+                    lat = float(line.split()[8])
+                except IndexError:
+                    self.logger.debug("Failed to parse lon or lat from %s", line)
+                    continue
                 end_dt = parse("{}-{}-{} {}:{}:{}".format(*line.split()[:6]))
-                lon = float(line.split()[7])
-                lat = float(line.split()[8])
                 end_point = Point((lon, lat), srid=4326)
                 end_depth = float(line.split()[11])
 

--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -364,7 +364,7 @@ class FNVLoader(BaseLoader):
                         os.path.join(path, item),
                     )
                 elif ma := re.match(r"(.+)(\.mb\d\d)", item):
-                    # Prefer processes '*p.mb8[8-9]' files
+                    # Prefer processed '*p.mb8[8-9]' files
                     fnv_type = "processed"
                     fnv_file = os.path.join(
                         path,
@@ -452,17 +452,17 @@ class FNVLoader(BaseLoader):
     ) -> Tuple[int, LineString]:
         """Can tune the quality of simplified LineString by adjusting
         `interval` and `tolerance`. Reasonable defaults are provided
-        for quick rendering of maybe 100 Missions on a Leaflet map."""
+        for quick rendering of maybe 600 Missions on a Leaflet map."""
         point_list = []
         for fnv_file in fnv_list:
             try:
                 subsample = self.fnv_determine_subsample(fnv_file, interval)
                 break
             except EOFError as e:
-                self.logger.warning(e)
+                self.logger.debug(e)
         if "subsample" not in locals():
             self.logger.info("Not getting nav_track for this mission.")
-            return
+            return len(point_list), None
         line_count = 0
         for fnv in fnv_list:
             with open(fnv) as fh:

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -32,3 +32,19 @@ let feature = L.geoJSON(missions)
   })
   .addTo(map);
 map.fitBounds(feature.getBounds(), { padding: [100, 100] });
+map.on("zoomend", function () {
+  // Reduce precision from defaut 14 (!) to 4 digits
+  var xmin = map.getBounds().toBBoxString().split(",")[0];
+  var ymin = map.getBounds().toBBoxString().split(",")[1];
+  var xmax = map.getBounds().toBBoxString().split(",")[2];
+  var ymax = map.getBounds().toBBoxString().split(",")[3];
+  xmin = Math.round(parseFloat(xmin) * 10000) / 10000;
+  ymin = Math.round(parseFloat(ymin) * 10000) / 10000;
+  xmax = Math.round(parseFloat(xmax) * 10000) / 10000;
+  ymax = Math.round(parseFloat(ymax) * 10000) / 10000;
+  var bboxString = xmin.toString() + "," + ymin.toString();
+  bboxString += "," + xmax.toString() + "," + ymax.toString();
+  // Add bbox to query string
+  var bElement = document.getElementById("bounds");
+  bElement.setAttribute("value", bboxString);
+});

--- a/smdb/smdb/templates/pages/home.html
+++ b/smdb/smdb/templates/pages/home.html
@@ -28,7 +28,8 @@
       <form id="changelist-search" method="get">
         <div class="float-right"><!-- DIV needed for valid HTML -->
           <label for="searchbar"><img src="/static/admin/img/search.svg" alt="Search"></label>
-          <input type="text" size="40" name="q" value="" id="searchbar" autofocus="">
+          <input title="Search for Notes text or Mission name" type="text" size="30" name="q" value="" id="searchbar" autofocus="">
+          <input type="hidden" name="bounds" value="" id="bounds">
           <input type="submit" value="Search">
         </div>
       </form>


### PR DESCRIPTION
It's envisioned that this will speed the temporally bounded queries for when the map is zoomed into a particular area.

Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/88