### PR TITLE
Following time slider selection add min and max time bounds to the query

### DIFF
--- a/smdb/requirements/production.txt
+++ b/smdb/requirements/production.txt
@@ -2,6 +2,6 @@
 
 -r base.txt
 
-django-storages[boto3]==1.12  # https://github.com/jschneier/django-storages
+django-storages[boto3]==1.12.1  # https://github.com/jschneier/django-storages
 gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
 python-dateutil==2.8.2  # local.txt requirements must have this as a dependency - needed for load.py

--- a/smdb/smdb/static/js/SliderControl.js
+++ b/smdb/smdb/static/js/SliderControl.js
@@ -127,22 +127,22 @@ L.Control.SliderControl = L.Control.extend({
     return sliderContainer;
   },
   _updateCurrentDiv: function (startIdx, endIdx) {
-    this.$currentStartDiv.html(
-      this.extractTimestamp(
-        this.options.markers[startIdx].feature.properties[
-          this.options.timeAttribute
-        ],
-        this.options
-      )
+    var min_date = this.extractTimestamp(
+      this.options.markers[startIdx].feature.properties[
+        this.options.timeAttribute
+      ],
+      this.options
     );
-    this.$currentEndDiv.html(
-      this.extractTimestamp(
-        this.options.markers[endIdx].feature.properties[
-          this.options.timeAttribute
-        ],
-        this.options
-      )
+    var max_date = this.extractTimestamp(
+      this.options.markers[endIdx].feature.properties[
+        this.options.timeAttribute
+      ],
+      this.options
     );
+    this.$currentStartDiv.html(min_date);
+    $("#tmin").attr("value", min_date);
+    this.$currentEndDiv.html(max_date);
+    $("#tmax").attr("value", max_date);
   },
   onRemove: function (map) {
     //Delete all markers which where added via the slider and remove the slider div

--- a/smdb/smdb/static/js/SliderControl.js
+++ b/smdb/smdb/static/js/SliderControl.js
@@ -24,7 +24,8 @@ L.Control.SliderControl = L.Control.extend({
 
   extractTimestamp: function (time, options) {
     if (options.isEpoch) {
-      time = new Date(parseInt(time)).toString(); // this is local time
+      //time = new Date(parseInt(time)).toUTCShortFormat();  // not a function ?
+      time = new Date(parseInt(time)).toISOString();
     }
     return time.substr(
       options.startTimeIdx,
@@ -54,7 +55,24 @@ L.Control.SliderControl = L.Control.extend({
     // Create a control sliderContainer with a jquery ui slider
     var sliderContainer = L.DomUtil.create("div", "slider", this._container);
     $(sliderContainer).append(
-      '<div id="slider-min"></div><div id="leaflet-slider" style="inline-block; margin: 0 5px 0 5px;"></div><div id="slider-max"></div><div id="slider-current"><span class="start-time"></span>-<span class="end-time"></span></div>'
+      '<div class="row">' +
+        '  <div class="col-12">' +
+        '    <div id="leaflet-slider" style="inline-block; margin: 0 5px 0 5px;"></div>' +
+        "  </div>" +
+        "</div>" +
+        '<div class="row">' +
+        '  <div class="col-2">' +
+        '    <div id="slider-min" style="color: lightgrey;"></div>' +
+        "  </div>" +
+        '  <div class="col-8">' +
+        '    <div id="slider-current" style="text-align: center;">' +
+        '      <span class="start-time"></span> to <span class="end-time"></span>' +
+        "    </div>" +
+        "  </div>" +
+        '  <div class="col-2">' +
+        '    <div id="slider-max" style="text-align: right; color: lightgrey;"></div>' +
+        "  </div>" +
+        "</div>"
     );
     //Prevent map panning/zooming while using the slider
     $(sliderContainer).mousedown(function () {
@@ -104,20 +122,26 @@ L.Control.SliderControl = L.Control.extend({
     );
     this.$currentStartDiv = $("#slider-current .start-time", sliderContainer);
     this.$currentEndDiv = $("#slider-current .end-time", sliderContainer);
-    this._updateCurrentDiv(0, 1);
+    this._updateCurrentDiv(0, this.options.maxValue);
 
     return sliderContainer;
   },
   _updateCurrentDiv: function (startIdx, endIdx) {
     this.$currentStartDiv.html(
-      this.options.markers[startIdx].feature.properties[
-        this.options.timeAttribute
-      ]
+      this.extractTimestamp(
+        this.options.markers[startIdx].feature.properties[
+          this.options.timeAttribute
+        ],
+        this.options
+      )
     );
     this.$currentEndDiv.html(
-      this.options.markers[endIdx].feature.properties[
-        this.options.timeAttribute
-      ]
+      this.extractTimestamp(
+        this.options.markers[endIdx].feature.properties[
+          this.options.timeAttribute
+        ],
+        this.options
+      )
     );
   },
   onRemove: function (map) {

--- a/smdb/smdb/static/js/SliderControl.js
+++ b/smdb/smdb/static/js/SliderControl.js
@@ -140,9 +140,24 @@ L.Control.SliderControl = L.Control.extend({
       this.options
     );
     this.$currentStartDiv.html(min_date);
-    $("#tmin").attr("value", min_date);
     this.$currentEndDiv.html(max_date);
+    // Add to hidden form elements
+    $("#tmin").attr("value", min_date);
     $("#tmax").attr("value", max_date);
+    // Also add map bounds for when zoom event doesn't update them
+    var xmin = map.getBounds().toBBoxString().split(",")[0];
+    var ymin = map.getBounds().toBBoxString().split(",")[1];
+    var xmax = map.getBounds().toBBoxString().split(",")[2];
+    var ymax = map.getBounds().toBBoxString().split(",")[3];
+    // Reduce precision from defaut 14 (!) to 4 digits
+    xmin = Math.round(parseFloat(xmin) * 10000) / 10000;
+    ymin = Math.round(parseFloat(ymin) * 10000) / 10000;
+    xmax = Math.round(parseFloat(xmax) * 10000) / 10000;
+    ymax = Math.round(parseFloat(ymax) * 10000) / 10000;
+    document.getElementById("xmin").setAttribute("value", xmin);
+    document.getElementById("xmax").setAttribute("value", xmax);
+    document.getElementById("ymin").setAttribute("value", ymin);
+    document.getElementById("ymax").setAttribute("value", ymax);
   },
   onRemove: function (map) {
     //Delete all markers which where added via the slider and remove the slider div

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -44,11 +44,15 @@ map.on("zoomend", function () {
   ymax = Math.round(parseFloat(ymax) * 10000) / 10000;
   var bboxString = xmin.toString() + "," + ymin.toString();
   bboxString += "," + xmax.toString() + "," + ymax.toString();
-  // Add bbox to query string
-  var bElement = document.getElementById("bounds");
-  bElement.setAttribute("value", bboxString);
-  var mbElement = document.getElementById("map_bounds");
-  mbElement.innerHTML = bboxString;
+  // Add map bounds to form elements for next query
+  document.getElementById("xmin").setAttribute("value", xmin);
+  document.getElementById("xmax").setAttribute("value", xmax);
+  document.getElementById("ymin").setAttribute("value", ymin);
+  document.getElementById("ymax").setAttribute("value", ymax);
+  document.getElementById("map_bounds").innerHTML = bboxString;
+  // Remove any time constraints following zoom event
+  $("#tmin").removeAttr("value");
+  $("#tmax").removeAttr("value");
 });
 
 var sliderControl = L.control.sliderControl({

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -59,8 +59,8 @@ var sliderControl = L.control.sliderControl({
   range: true,
   showAllOnStart: true,
   alwaysShowDate: true,
-  startTimeIdx: 4,
-  timeStrLength: 8,
+  startTimeIdx: 0,
+  timeStrLength: 10,
 });
 map.addControl(sliderControl);
 $("#filter-center").html(sliderControl.getContainer());

--- a/smdb/smdb/templates/pages/home.html
+++ b/smdb/smdb/templates/pages/home.html
@@ -35,8 +35,13 @@
       <div class="col-3">
         <div class="float-right"><!-- div needed inside form for valid HTML -->
           <label for="searchbar"><img src="/static/admin/img/search.svg" alt="Search"></label>
-          <input title="Search for Notes text or Mission name" type="text" size="30" name="q" value="" id="searchbar" autofocus="">
-          <input type="hidden" name="bounds" value="" id="bounds">
+          <input title="Search for Notes text or Mission name" type="text" size="20" name="q" value="" id="searchbar" autofocus="">
+          <input type="hidden" name="xmin" value="" id="xmin">
+          <input type="hidden" name="xmax" value="" id="xmax">
+          <input type="hidden" name="ymin" value="" id="ymin">
+          <input type="hidden" name="ymax" value="" id="ymax">
+          <input type="hidden" name="tmin" value="" id="tmin">
+          <input type="hidden" name="tmax" value="" id="tmax">
           <input title="Query database with current selection" type="submit" value="Update">
         </div>
       </div>

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -40,10 +40,11 @@ class MissionOverView(TemplateView):
         context = super().get_context_data(**kwargs)
         search_string = context["view"].request.GET.get("q")
         search_geom = None
-        if context["view"].request.GET.get("bounds"):
-            min_lon, min_lat, max_lon, max_lat = (
-                context["view"].request.GET.get("bounds").split(",")
-            )
+        if context["view"].request.GET.get("xmin"):
+            min_lon = context["view"].request.GET.get("xmin")
+            max_lon = context["view"].request.GET.get("xmax")
+            min_lat = context["view"].request.GET.get("ymin")
+            max_lat = context["view"].request.GET.get("ymax")
             search_geom = Polygon(
                 (
                     (float(min_lon), float(min_lat)),
@@ -63,6 +64,13 @@ class MissionOverView(TemplateView):
             )
         if search_geom:
             missions = missions.filter(grid_bounds__contained=search_geom)
+        if context["view"].request.GET.get("tmin"):
+            min_date = context["view"].request.GET.get("tmin")
+            max_date = context["view"].request.GET.get("tmax")
+            missions = missions.filter(
+                start_date__gte=min_date,
+                end_date__lte=max_date,
+            )
 
         self.logger.info(
             "Serializing %s missions to geojson...",

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -54,7 +54,7 @@ class MissionOverView(TemplateView):
                 ),
                 srid=4326,
             )
-        missions = Mission.objects.all()
+        missions = Mission.objects.order_by("start_date").all()
         if search_string:
             self.logger.info("search_string = %s", search_string)
             missions = missions.filter(


### PR DESCRIPTION
Some usability testing is in order with these changes. How does one make selections using Leaflet's Zoom and time range selector? Sometimes we want to reset constraints following some event – for instance remove time bounds following a zoom event. 

Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/88