### PR TITLE
Skip over blank lines in exclude.list file

### DIFF
--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -186,7 +186,7 @@ class BaseLoader:
 
         if not self.exclude_paths:
             for line in open(self.args.exclude):
-                if not line.startswith("#"):
+                if line.startswith("/mbari/SeafloorMapping/"):
                     self.exclude_paths.append(line.strip())
 
         self.logger.debug(


### PR DESCRIPTION
Do this by making sure the line starts with '/mbari/SeafloorMapping'.