### PR TITLE
Leave boolean fields null unless a value is in the column

### DIFF
--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -1612,13 +1612,11 @@ class SurveyTally(BaseLoader):
                     mission.lass = row["LASS"] == "x"
                 except KeyError:
                     pass
-                mission.patch_test = (
-                    row["Patch_test"].lower() == "x" or row["Patch_test"].lower == "yes"
-                )
-                mission.repeat_survey = (
-                    row["Repeat_survey"].lower() == "x"
-                    or row["Repeat_survey"].lower == "yes"
-                )
+                # If anything is in the Patch_test or Repeat_survey columns, set the field to True
+                if row["Patch_test"]:
+                    mission.patch_test = True
+                if row["Repeat_survey"]:
+                    mission.repeat_survey = True
                 # mission.track_length = row["Trackline_km"]  # Do not update database with this field
                 mission.mgds_compilation = row["MGDS_compilation"]
                 mission.save()


### PR DESCRIPTION
This will make the appearance of the Patch_test and Repeat_survey columns better by have a '-' unless it's checked with an 'x', 'yes', or now anything in the spreadsheet. Removed values in the production database with:
```
Mission.objects.exclude(patch_test__isnull=True).update(patch_test=None)
Mission.objects.exclude(repeat_survey__isnull=True).update(repeat_survey=None)
```
Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/206