### PR TITLE
Pass exclude_paths to bootstrap_load() - there are different BaseLoder objects in main()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,6 +46,7 @@
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "2023/20230310m1/ZTopo.grd$", "--limit", "10" ],
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "2024/20240510m1/ZTopo.grd$", "--limit", "10" ],
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "MappingAUVOps2008/20080320/ZTopo.grd$", "--limit", "3" ],
+      "args": [ "-v", "1", "--skipuntil_regex", "--regex", "swathdata/surveys/NOAA/AHI-06-05ZTopo.grd$", "--limit", "2" ],
       //"args": ["-v", "1", "--limit", "5", "--clobber", "--noinput"],
       //"args": ["--bootstrap", "-v 1", "--clobber", "--limit", "5", "--noinput"],
       //"args": ["--bootstrap", "-v 2", "--limit", "10" "--clobber", "--noinput"],
@@ -68,6 +69,7 @@
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2022/20220205m1"]
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2020/20200804m1"]
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2023/20230310m1"]
+      //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "swathdata/surveys/NOAA/AHI-06-05"]
       //"args": ["--fnv", "-v", "2"],
       //"args": [ "--compilation", "-v", "1", "--skipuntil", "swathdata/surveys/UH/kok0714", "--log_file", "compilation.txt" ],
       // Supporting Compilation load testing, first mission found in --compilation: 2019/20190627d1/multibeam
@@ -83,7 +85,7 @@
       //"args": ["--compilation", "-v", "1", "--skipuntil", "2022/AxialSeamount/FiguresCaress", "--limit", "10", "--log_file", "compilation.txt"],
       //"args": ["--compilation", "-v", "1"],
       //"args": ["--spreadsheets", "-v", "1"],
-      "args": ["-v", "2", "--last_n_days", "0.5"],
+      //"args": ["-v", "2", "--last_n_days", "0.5"],
       //"args": ["-v", "1", "--spreadsheets", "--parent_dir", "2024", "--append_to_log_file"],
       //"args": ["-v", "1", "--spreadsheets"],
       //"args": ["-v", "1", "--compilation", "--last_n_days", "30"],

--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -1856,8 +1856,8 @@ def run(*args):
     elif bl.args.spreadsheets:
         spreadsheets_load()
     else:
-        exclude_file_load()
-        missions_saved = bootstrap_load()
+        exclude_paths = exclude_file_load()
+        missions_saved = bootstrap_load(exclude_paths)
         notes_load(missions_saved)
         fnv_load(missions_saved)
         compilation_load()
@@ -1873,10 +1873,12 @@ def exclude_file_load():
     ef.read_exclude_path_xlsxs()
     ef.write_exclude_path_csvs()
     ef.write_consolidated_exclude_list()
+    return ef.exclude_paths
 
 
-def bootstrap_load() -> list:
+def bootstrap_load(exclude_paths) -> list:
     bs = BootStrapper()
+    bs.exclude_paths = exclude_paths
     bs.process_command_line()
     bs.load_from_grds()
     return bs.missions_saved


### PR DESCRIPTION
Applies to https://github.com/mbari-org/SeafloorMappingDB/issues/249