### PR TITLE
Fix: Home page map tooltip shows 'Invalid Date' and 'null' for route

### DIFF
--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -1408,8 +1408,9 @@ let feature = L.geoJSON(missions, {
           day: "numeric",
         });
       }
-    } else {
-      // Fall back to extracting date from slug (e.g. mappingauvops2024-20240201m1)
+    }
+    // Fall back to slug parsing if start_date is missing or unparseable
+    if (dateOfMission === "Unknown") {
       var slugTail = layer.feature.properties.slug.replace(/.*-/, "");
       slugTail = slugTail.replace(/(\d)([^\d\s%])/g, "$1 $2");
       var datePart = slugTail.substring(0, 8).replace(
@@ -1430,12 +1431,13 @@ let feature = L.geoJSON(missions, {
     // --- Route: show "Not Available" when no route file is recorded ---
     var routeFile = layer.feature.properties.route_file || "Not Available";
 
+    // --- Escape DB-backed values before inserting into tooltip HTML ---
     var tooltipInfo =
-      layer.feature.properties.slug +
+      escapeHtml(layer.feature.properties.slug) +
       "<br>Date: " +
       dateOfMission +
       "<br>Route: " +
-      routeFile;
+      escapeHtml(routeFile);
     return tooltipInfo;
   })
   .addTo(map);


### PR DESCRIPTION
## Summary

- **Date fix**: The hover tooltip on the home page map was parsing the mission date from the slug string (e.g. `mappingauvops2024-20240201m1`), which fails for non-standard slug formats and renders as `"Invalid Date"`. Now uses `start_date` directly from the GeoJSON feature properties (already serialized by `MissionSerializer`) as the primary source, with slug-parsing as a fallback and `"Unknown"` as a last resort.
- **Route fix**: When `route_file` is `null` in the database, JavaScript string concatenation was rendering the literal word `"null"` in the tooltip. Now displays `"Not Available"` to clearly communicate the data is not yet recorded.

## Files changed

- `smdb/smdb/static/js/map.js` — `bindTooltip` function only

## Test plan

- [ ] All 167 existing pytest tests pass (`pytest -v`)
- [ ] Hover over a mission track on the home page map — date displays correctly (e.g. "Thursday, Feb 1, 2024")
- [ ] For missions without a route file recorded, tooltip shows "Route: Not Available" instead of "Route: null"
- [ ] For missions without a `start_date` in the database, date falls back to slug-parsed value or "Unknown"