### PR TITLE
The assumption "Assume no comments at end of file" was incorrect.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,7 +71,8 @@
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2020/20200804m1"]
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "2023/20230310m1"]
       //"args": ["--fnv", "-v", "2", "--limit", "2", "--skipuntil", "swathdata/surveys/NOAA/AHI-06-05"]
-      "args": ["--fnv", "-v", "1"],
+      "args": ["--fnv", "-v", "2", "--limit", "1", "--skipuntil", "2026/20260301m2"]
+      //"args": ["--fnv", "-v", "1"],
       //"args": [ "--compilation", "-v", "1", "--skipuntil", "swathdata/surveys/UH/kok0714", "--log_file", "compilation.txt" ],
       // Supporting Compilation load testing, first mission found in --compilation: 2019/20190627d1/multibeam
       // execute next line to build a fresh database, then the --compilation one can be used for testing
@@ -93,6 +94,7 @@
       //"args": [ "-v", "2", "--skipuntil_regex", "--regex", "Packard/2025/DP2025_01/RogueCanyonLeg1/ZTopo.grd$", "--limit", "1", "--noinput" ],
       //"args": [ "-v", "2", "--bootstrap", "--skipuntil_regex", "--regex", "2019/20190628d1/lidar/ZTopo.grd$", "--limit", "1", "--noinput" ],
       //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "2026/20260322m1/ZTopo.grd$", "--limit", "1", "--noinput" ]
+      //"args": [ "-v", "1", "--skipuntil_regex", "--regex", "2026/20260301m2/ZTopo.grd$", "--limit", "1", "--noinput" ]
     }
   ]
 }

--- a/smdb/scripts/load.py
+++ b/smdb/scripts/load.py
@@ -786,25 +786,28 @@ class FNVLoader(BaseLoader):
             raise ParserError(f"Could not get start_dt from {fh.name}")
         for fnv_file in reversed(fnv_list):
             with open(fnv_file) as fh:
-                try:
-                    # Assume no comments at end of file
-                    line = fh.readlines()[-1]
-                except IndexError:
-                    self.logger.debug("Cannot read last record from %s", fnv_file)
-                    continue
-                try:
-                    end_dt = parse("{}-{}-{} {}:{}:{}".format(*line.split()[:6]))
-                except IndexError:
-                    self.logger.debug("Failed to parse datetime from %s", line)
-                    continue
-                try:
-                    lon = float(line.split()[7])
-                    lat = float(line.split()[8])
-                except IndexError:
-                    self.logger.debug("Failed to parse lon or lat from %s", line)
-                    continue
-                end_point = Point((lon, lat), srid=4326)
-                end_depth = float(line.split()[11])
+                lines = fh.readlines()
+            line = None
+            for candidate in reversed(lines):
+                if not candidate.startswith("#") and candidate.strip():
+                    line = candidate
+                    break
+            if line is None:
+                self.logger.debug("Cannot read last record from %s", fnv_file)
+                continue
+            try:
+                end_dt = parse("{}-{}-{} {}:{}:{}".format(*line.split()[:6]))
+            except IndexError:
+                self.logger.debug("Failed to parse datetime from %s", line)
+                continue
+            try:
+                lon = float(line.split()[7])
+                lat = float(line.split()[8])
+            except IndexError:
+                self.logger.debug("Failed to parse lon or lat from %s", line)
+                continue
+            end_point = Point((lon, lat), srid=4326)
+            end_depth = float(line.split()[11])
             break
         if "end_dt" not in locals():
             raise ParserError(f"Could not get end_dt from {fh.name}")


### PR DESCRIPTION
Change the logic to iterate backwards from the list of processed .fnv files to find the end time. File "/Volumes/SeafloorMapping/2026/20260301m2/20260302_220104p.mb89.fnv" has just one line, the header line, which caused the problem.